### PR TITLE
Updated the MAGE page

### DIFF
--- a/mage/index.html
+++ b/mage/index.html
@@ -164,20 +164,16 @@
 			</h2>
 
 			<p>
-				We will be releasing MAGE open source very soon. If you are interested in using MAGE
-				or if you wish to know more about MAGE, please register on our waiting list below.
-				You will receive a notification as soon as it gets released.<br/>
-				<a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLScBd5Oo0yOE3aIEHAknPGoMHxzGKC94npsIXxzyr1Q0QqTupw/viewform">
-					Click here to register (English)
-				</a>
+				MAGE is now Open Source! You can download and install it from <a href="https://www.npmjs.com/package/mage">NPM</a>
+				and read the documentation on <a href="https://mage.github.io/mage">GitHub</a>. You can follow us on
+				<a href="https://twitter.com/mageframework">Twitter</a> to stay up-to-date on the latest news.
 			</p>
 
 			<p class="jp">
-				MAGEはもうじきオープンソースでリリースする予定です。ご興味のある方は下記のリンクで
-				ウェイティングリストにご登録頂ければ、リリースした際ご連絡させて頂きます。<br/>
-				<a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeZlU1p9A_aJBks_tK-8j9aRDoYC3i564mwmR2dCm2LgndmHA/viewform">
-					ご登録はこちらへ（日本語）
-				</a>
+				MAGEがついにオープンソースに！<br/>
+				<a href="https://www.npmjs.com/package/mage">NPM</a>からダウンロード・インストール​、
+				<a href="https://mage.github.io/mage">​GitHub</a>​上にてドキュメントも公開しています。​<br/>
+				最新情報は<a href="https://twitter.com/mageframework">Twitter​</a>上に随時更新していきますのでフォローしてください！​
 			</p>
 
 			<p class="copyright">Copyright © 2017 Wizcorp Inc.</p>


### PR DESCRIPTION
This removes the Google form from the page and replaces it with information on where to get (information on) MAGE.